### PR TITLE
Added managedby and repository to dependencies.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,9 @@ module "auth-role" {
 
   policy_enabled = true
   policy         = data.aws_iam_policy_document.authenticated.json
+
+  managedby = var.managedby
+  repository  = var.repository
 }
 
 data "aws_iam_policy_document" "authenticated_assume" {
@@ -79,6 +82,9 @@ module "unauth-role" {
 
   policy_enabled = true
   policy         = data.aws_iam_policy_document.unauthenticated.json
+
+  managedby = var.managedby
+  repository  = var.repository  
 }
 
 data "aws_iam_policy_document" "unauthenticated_assume" {


### PR DESCRIPTION
## What
* Managedby and repository variables are passed to submodules, avoiding the creation of inconsistent tags.

## Why
* The module does not pass variables that have deafult values like managedby, this makes it impossible to pass them to submodules, at least with Terragrunt.

## Considerations
I would avoid putting values in tags or names by default that are not strictly necessary for the service to work, or at least leave it up to the user to choose whether to use them with a boolean.
